### PR TITLE
feat: adiciona Google Analytics (G-J4D6L1PN68)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -81,6 +81,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="antialiased">
         {children}
 
+        {/* Google Analytics */}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-J4D6L1PN68"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-J4D6L1PN68');
+          `}
+        </Script>
+
         {/* Scripts */}
         <Script src="/js/plugins/jquery.min.js" strategy="afterInteractive" />
         <Script src="/js/plugins/swup.min.js" strategy="afterInteractive" />


### PR DESCRIPTION
Usa next/script com strategy="afterInteractive" para não bloquear a renderização. O script gtag.js é carregado após a hidratação da página, seguindo a recomendação do Next.js para scripts de terceiros.